### PR TITLE
Validate object checksum during pull

### DIFF
--- a/client/object.go
+++ b/client/object.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const refSeparator = "#"
+
+type ObjectReference struct {
+	oid      string
+	checksum string
+}
+
+func parseObjectReference(input string) (*ObjectReference, error) {
+	split := strings.SplitN(input, refSeparator, 2)
+	if len(split) != 2 {
+		return nil, fmt.Errorf("malformed object reference")
+	}
+
+	or := &ObjectReference{
+		oid: split[0],
+		checksum: split[1],
+	}
+	return or, nil
+}
+
+func (or *ObjectReference) String() string {
+	return fmt.Sprintf("%s%s%s", or.oid, refSeparator, or.checksum)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -55,7 +55,7 @@ func loadConfig() {
 		viper.SetConfigFile(confFile)
 		logger.Infof("Loading configuration from %s\n", confFile)
 	} else {
-		dir := filepath.Join("~", lib.DefaultConfigDir)
+		dir := filepath.Join("$HOME", lib.DefaultConfigDir)
 		viper.AddConfigPath(dir)
 		viper.SetConfigName(lib.DefaultConfigName)
 		viper.SetConfigType(lib.DefaultConfigType)


### PR DESCRIPTION
Store a checksum in the "user-visible" object reference, which can be used to verify the integrity of the object when it is pulled.

closes #28 